### PR TITLE
Add simple HTML chat interface for Llama

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Llama Chat</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; padding: 0; }
+    #chat { height: 80vh; overflow-y: auto; padding: 1rem; border-bottom: 1px solid #ccc; }
+    .message { margin: 0.5rem 0; }
+    .user { text-align: right; color: blue; }
+    .bot { text-align: left; color: green; }
+    #inputArea { display: flex; }
+    #inputArea input { flex: 1; padding: 0.5rem; }
+    #inputArea button { padding: 0.5rem; }
+  </style>
+</head>
+<body>
+  <div id="chat"></div>
+  <div id="inputArea">
+    <input id="message" type="text" placeholder="Type your message" />
+    <button id="send">Send</button>
+  </div>
+
+  <script>
+    const chat = document.getElementById('chat');
+    const input = document.getElementById('message');
+    const sendBtn = document.getElementById('send');
+
+    async function sendMessage() {
+      const text = input.value.trim();
+      if (!text) return;
+      appendMessage('user', text);
+      input.value = '';
+
+      try {
+        const res = await fetch('/api/llama', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ prompt: text })
+        });
+        const data = await res.json();
+        appendMessage('bot', data.answer || data.error || 'No response');
+      } catch (err) {
+        appendMessage('bot', 'Error: ' + err.message);
+      }
+    }
+
+    function appendMessage(role, text) {
+      const msg = document.createElement('div');
+      msg.className = `message ${role}`;
+      msg.textContent = text;
+      chat.appendChild(msg);
+      chat.scrollTop = chat.scrollHeight;
+    }
+
+    sendBtn.addEventListener('click', sendMessage);
+    input.addEventListener('keydown', e => {
+      if (e.key === 'Enter') sendMessage();
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `index.html` with basic chat UI and fetches to `/api/llama`

## Testing
- `npm test` *(fails: ENOENT: no such file or directory)*
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b52c5ca50c8332a912b7a0573d9303