### PR TITLE
Add JSON action controller module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# LMA Controller
+
+The `controller.py` module exposes a small JSON-based API around the Llama chat model.
+
+## Prompting the model
+
+Provide a system prompt instructing the model to respond with a JSON action. For example:
+
+```
+You are an assistant that chooses from available actions and responds ONLY with JSON.
+To tell a story, reply with:
+{"action": "tell_story", "args": {"topic": "<topic>"}}
+```
+
+When the model emits that JSON, pass it to `handle_request` to perform the action.

--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ To tell a story, reply with:
 ```
 
 When the model emits that JSON, pass it to `handle_request` to perform the action.
+
+Running the `tell_story` action returns the generated text and also saves it to a
+file named `story_<topic>.txt` in the current working directory, with the topic
+slugified for filesystem safety.

--- a/controller.py
+++ b/controller.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from typing import Any, Callable, Dict
 
 from llama import Llama
@@ -35,10 +36,21 @@ generator = Llama.build(
 
 
 def tell_story(topic: str) -> str:
-    """Ask the model to tell a story about ``topic``."""
+    """Ask the model to tell a story about ``topic`` and save it to a file."""
     dialog = [[{"role": "user", "content": f"tell me a story about {topic}"}]]
     result = generator.chat_completion(dialog)[0]
-    return result["generation"]["content"]
+    story = result["generation"]["content"]
+
+    filename = f"story_{_slugify(topic)}.txt"
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(story)
+
+    return story
+
+
+def _slugify(text: str) -> str:
+    """Return a filesystem-friendly slug of ``text``."""
+    return re.sub(r"[^a-zA-Z0-9_-]", "_", text).lower()
 
 
 ACTIONS: Dict[str, Callable[..., Any]] = {

--- a/controller.py
+++ b/controller.py
@@ -1,0 +1,56 @@
+"""
+Simple JSON-driven controller for Llama.
+
+The model can be guided to call these actions by using a system prompt such as:
+
+    You are a helpful assistant that chooses actions instead of answering directly.
+    When asked to tell a story, respond with JSON of the form
+    {"action": "tell_story", "args": {"topic": "<topic>"}}.
+
+`handle_request` consumes such JSON commands and dispatches to the
+corresponding Python function.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Callable, Dict
+
+from llama import Llama
+
+# Build the Llama generator the same way as in example_chat_completion.py.
+# Paths can be provided via environment variables so this module remains
+# configuration agnostic.
+CKPT_DIR = os.environ.get("LLAMA_CKPT_DIR", "path/to/ckpt")
+TOKENIZER_PATH = os.environ.get("LLAMA_TOKENIZER_PATH", "path/to/tokenizer")
+
+# Initialize the generator at import time to be reused across requests.
+generator = Llama.build(
+    ckpt_dir=CKPT_DIR,
+    tokenizer_path=TOKENIZER_PATH,
+    max_seq_len=512,
+    max_batch_size=4,
+)
+
+
+def tell_story(topic: str) -> str:
+    """Ask the model to tell a story about ``topic``."""
+    dialog = [[{"role": "user", "content": f"tell me a story about {topic}"}]]
+    result = generator.chat_completion(dialog)[0]
+    return result["generation"]["content"]
+
+
+ACTIONS: Dict[str, Callable[..., Any]] = {
+    "tell_story": tell_story,
+}
+
+
+def handle_request(request_json: str) -> Any:
+    """Parse a JSON command and dispatch to the requested action."""
+    data = json.loads(request_json)
+    action = data.get("action")
+    args = data.get("args", {})
+    if action not in ACTIONS:
+        raise ValueError(f"Unknown action: {action}")
+    return ACTIONS[action](**args)


### PR DESCRIPTION
## Summary
- add controller module that builds a Llama generator
- implement tell_story action with JSON dispatch via `handle_request`
- document system prompt example for emitting JSON action

## Testing
- `python -m py_compile controller.py`


------
https://chatgpt.com/codex/tasks/task_e_68b531db90b88332bd07864791b38091